### PR TITLE
DEV-260: Add auto-filled timestamp of index, for sorting OAI requests

### DIFF
--- a/solr/catalog/conf/schema.xml
+++ b/solr/catalog/conf/schema.xml
@@ -167,15 +167,20 @@
    -->
    <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
 
-   <!-- Only remove the "id" field if you have a very good reason to. While not strictly
-     required, it is highly recommended. A <uniqueKey> is present in almost all Solr
-     installations. See the <uniqueKey> declaration below where <uniqueKey> is set to "id".
-     Do NOT change the type and apply index-time analysis to the <uniqueKey> as it will likely
-     make routing in SolrCloud and document replacement in general fail. Limited _query_ time
-     analysis is possible as long as the indexing process is guaranteed to index the term
-     in a compatible way. Any analysis applied to the <uniqueKey> should _not_ produce multiple
-     tokens
-   -->
+   <!-- Time of index -->
+
+   <field name="time_of_index" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
+
+
+    <!-- Only remove the "id" field if you have a very good reason to. While not strictly
+      required, it is highly recommended. A <uniqueKey> is present in almost all Solr
+      installations. See the <uniqueKey> declaration below where <uniqueKey> is set to "id".
+      Do NOT change the type and apply index-time analysis to the <uniqueKey> as it will likely
+      make routing in SolrCloud and document replacement in general fail. Limited _query_ time
+      analysis is possible as long as the indexing process is guaranteed to index the term
+      in a compatible way. Any analysis applied to the <uniqueKey> should _not_ produce multiple
+      tokens
+    -->
    <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
 
 


### PR DESCRIPTION
Adds an auto-filled timestamp of time of index. Solr config only, requires nothing on the indexing side of the code.