### PR TITLE
Update schema version to 1.6 and lucene version to 8.6

### DIFF
--- a/solr/catalog/conf/schema.xml
+++ b/solr/catalog/conf/schema.xml
@@ -74,7 +74,7 @@
  http://wiki.apache.org/solr/SchemaXml
 -->
 
-<schema name="mirlyn_ht_catalog" version="0.1">
+<schema name="mirlyn_ht_catalog" version="1.6">
   <!-- attribute "name" is the name of this schema and is only used for display purposes.
        version="x.y" is Solr's version number for the schema syntax and
        semantics.  It should not normally be changed by applications.

--- a/solr/catalog/conf/solrconfig.xml
+++ b/solr/catalog/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>6.0.0</luceneMatchVersion>
+  <luceneMatchVersion>8.6.0</luceneMatchVersion>
 
   <!-- Data Directory
 

--- a/solr/catalog/core.properties
+++ b/solr/catalog/core.properties
@@ -1,5 +1,5 @@
 #Written by CorePropertiesLocator
-#Fri Dec 10 15:07:03 UTC 2021
+#Fri May 13 15:47:46 UTC 2022
 dataDir=data
 name=catalog
 config=solrconfig.xml


### PR DESCRIPTION
Makes parsing more efficient and eliminates deprecation warnings.