### PR TITLE
DEV-18 Make sure CJK bigrams are generated before keywordRepeat

### DIFF
--- a/solr/catalog/conf/schema/basic_text_chain.xml
+++ b/solr/catalog/conf/schema/basic_text_chain.xml
@@ -26,9 +26,10 @@
 
 <filter class="solr.ICUFoldingFilterFactory"/>
 <filter class="solr.DecimalDigitFilterFactory"/>
-<filter class="solr.KeywordRepeatFilterFactory"/>
 <filter class="solr.CJKWidthFilterFactory"/>
 <filter class="solr.CJKBigramFilterFactory"/>
+<filter class="solr.KeywordRepeatFilterFactory"/>
+
 
 
 

--- a/solr/catalog/conf/schema/basic_text_chain_with_synonyms.xml
+++ b/solr/catalog/conf/schema/basic_text_chain_with_synonyms.xml
@@ -24,12 +24,11 @@
 <!--<charFilter class="solr.MappingCharFilterFactory" mapping="&char_expansion_file;"/>-->
 <tokenizer class="solr.ICUTokenizerFactory"/>
 <filter class="solr.ICUFoldingFilterFactory"/>
-
-<filter class="solr.SynonymGraphFilterFactory" synonyms="&synonym_file;" ignoreCase="true" expand="true"/>
-<filter class="solr.FlattenGraphFilterFactory" />
-
 <filter class="solr.DecimalDigitFilterFactory"/>
-<filter class="solr.KeywordRepeatFilterFactory"/>
 <filter class="solr.CJKWidthFilterFactory"/>
 <filter class="solr.CJKBigramFilterFactory"/>
+<filter class="solr.SynonymGraphFilterFactory" synonyms="&synonym_file;" ignoreCase="true" expand="true"/>
+<filter class="solr.FlattenGraphFilterFactory" />
+<filter class="solr.KeywordRepeatFilterFactory"/>
+
 

--- a/solr/catalog/conf/schema/text_types.xml
+++ b/solr/catalog/conf/schema/text_types.xml
@@ -1,4 +1,4 @@
-!--    ............................
+<!--    ............................
         :     Text types           :
         ............................
 
@@ -58,9 +58,9 @@
                 pattern="^\p{Punct}*(.*?)\p{Punct}*$" replacement="aaaaa$1" />
     <tokenizer class="solr.ICUTokenizerFactory"/>
     <filter class="solr.ICUFoldingFilterFactory"/>
+    <filter class="solr.DecimalDigitFilterFactory"/>
     <filter class="solr.CJKWidthFilterFactory"/>
     <filter class="solr.CJKBigramFilterFactory"/>
-    <filter class="solr.DecimalDigitFilterFactory"/>
     <filter class="solr.KeywordRepeatFilterFactory"/>
       &stemmer;
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>


### PR DESCRIPTION
The CJK bigram generator is apparently not "keyword aware"
and can't handle having multiple tokens at the same offset.

This reorders analysis chains when necessary to make sure
the `KeywordRepeatFilterFactory` is always called
_after_ the CJK transforms.

This eliminates errors thrown when indexing CJK (only those with unusual UTF composition?) under solr 8