### PR TITLE
Add instructions for building a sample index.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,32 @@ docker-compose up -d solr-sdr-catalog
 docker-compose run --rm traject bundle install
 ```
 
-### Index one file
+### Generate Solr documents
+
+Generate Solr documents given an input file of MARC records in JSON format, one per line:
+
+```
+docker-compose run traject bin/tindex json input-marc-records.jsonl 
+```
+
+Output will be in `debug.json`.
+
+### Building a Sample Index Docker Image
+
+This will build a docker image with a Solr core pre-loaded with a set of records.
+
+* As above, put records you want to load in `example-index/records-to-index.jsonl`
+
+* Then run:
+
+```
+docker build . -f example-index/Dockerfile -t my-sample-solr
+```
+
+and run e.g. `docker run -p 9033:9033 my-sample-solr`, or use in another
+`docker-compose.yml`, etc.
+
+### Index one file into Solr
 
 Index a file of records without using the database or hardcoded filesystem paths:
 

--- a/example-index/Dockerfile
+++ b/example-index/Dockerfile
@@ -1,0 +1,72 @@
+# First, transform the MARC in JSON into Solr documents
+
+FROM jruby:9.3 AS traject
+
+ARG UNAME=app
+ARG UID=1000
+ARG GID=1000
+
+RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
+  build-essential
+
+RUN groupadd -g ${GID} -o ${UNAME}
+RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash ${UNAME}
+RUN mkdir -p /gems && chown ${UID}:${GID} /gems
+
+COPY --chown=${UID}:${GID} ./Gemfile* /app/
+USER $UNAME
+
+ENV BUNDLE_PATH /gems
+RUN mkdir -p /gems 
+
+
+WORKDIR /app
+
+COPY ./Gemfile /app
+RUN bundle install
+COPY . /app
+
+ENV redirect_file /dev/null
+ENV NO_DB 1
+
+# outputs /app/debug.json
+# records-to-index.json should be in ./example-index
+RUN bin/tindex json example-index/records-to-index.jsonl
+
+FROM solr:8.11 AS indexer
+
+ENV SOLR_PORT=9033
+
+COPY --chown=solr:solr ./solr /var/solr/data
+COPY --from=traject /app/debug.json /tmp/solrdocs.jsonl
+COPY ./example-index/load_into_solr.sh /tmp
+
+# The solr:8 Dockerfile includes
+#
+# VOLUME /var/solr 
+# https://github.com/docker-solr/docker-solr/blob/master/8.11/Dockerfile#L118
+# 
+#
+# Among other things, this means that anything we write to /var/solr/data
+# during a RUN command will be lost:
+# https://docs.docker.com/engine/reference/builder/#volume
+# (Things copied with COPY do appear to persist.)
+#
+# Using multi-stage builds allows us to build the data, storing it in
+# /tmp/biblio, and then copying from that temporary image into our final output
+# image, in a way somewhat reminiscent of our current build/release process.
+
+RUN mkdir /tmp/catalog-data && \
+    ln -s /tmp/catalog-data /var/solr/data/catalog/data && \
+    start-local-solr && \
+    bash /tmp/load_into_solr.sh && \
+    stop-local-solr
+
+FROM solr:8.11
+
+LABEL org.opencontainers.image.source https://github.com/hathitrust/hathitrust_catalog_indexer
+
+ENV SOLR_PORT=9033
+
+COPY --chown=solr:solr ./solr /var/solr/data
+COPY --from=indexer /tmp/catalog-data /var/solr/data/catalog/data

--- a/example-index/load_into_solr.sh
+++ b/example-index/load_into_solr.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+SOLR_URL="http://localhost:9033/solr/catalog"
+input="/tmp/solrdocs.jsonl"
+echo "Indexing records into Solr..."
+nrec=$(cat $input | wc -l)
+i=0
+while IFS= read -r line
+do
+  let i++
+  cat <<-EOT | curl -s -X POST -H "Content-Type:application/json"  --data-binary @- "$SOLR_URL/update/json/docs" > /dev/null
+  [$line]
+	EOT
+  if (( $i % 50 == 0 || $i == $nrec )); then
+    echo -ne "$i / $nrec records indexed\r"
+  fi
+done < "$input"
+echo 
+
+echo "Committing"
+curl -s -H "Content-Type: application/json" -X POST -d'{"commit": {}}' "$SOLR_URL/update?wt=json"
+echo "Done"


### PR DESCRIPTION
Output is at https://github.com/hathitrust/hathitrust_catalog_indexer/pkgs/container/catalog-solr-sample with 2,000 random records that were updated May 1, 2022.