### PR TITLE
DEV-150 delete as empty record

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development do
 end
 
 gem 'httpclient'
+gem 'httpx'
 gem 'library_stdnums'
 gem 'match_map'
 gem 'sequel'

--- a/bin/delete_ids
+++ b/bin/delete_ids
@@ -1,4 +1,4 @@
-require 'httpclient'
+require 'httpx'
 require 'zlib'
 
 filename = ARGV[0]
@@ -14,7 +14,11 @@ end
 
 
 
-client = HTTPClient.new
+client = HTTPX.with(headers: {'Content-Type' => 'application/json'})
+
+def deleted_doc(id)
+  {id: id, deleted: true }
+end
 
 total = 0
 begin
@@ -23,19 +27,13 @@ begin
     file = Zlib::GzipReader.new(file)
   end
 
-  body = "<delete>"
-  file.each do |l|
-    body << "<id>#{l.chomp}</id>"
-    total += 1
-  end
-  body << "</delete>"
-
-  if total > 0
-    client.post(url, body, {'Content-Type' => 'text/xml'})  
+  docs = file.map{|x| deleted_doc(x.chomp) }
+  if docs.size > 0
+    client.post(url, json: docs)
   else
     puts "File #{filename} is empty"
   end
-  puts "Deleted #{total} ids from #{url}\n\n"
+  puts "Deleted #{docs.size} ids from #{url}\n\n"
 rescue Exception => e
   puts "Problem deleting: #{e}"
 end

--- a/solr/catalog/conf/schema.xml
+++ b/solr/catalog/conf/schema.xml
@@ -188,6 +188,8 @@
       Unless this field is marked with required="false", it will be a required field
    -->
  <uniqueKey>id</uniqueKey>
+    <field name="deleted" type="boolean" indexed="true" stored="true" multiValued="false" default="false"/>
+
 
 
     <!-- IDs that used to be valid for this set of HTIDs -->
@@ -198,7 +200,7 @@
 
  <!-- Core Fields  -->
 
- <field name="id_int"          type="long"      indexed="true" stored="true"/>
+ <field name="id_int"          type="long"      indexed="true" stored="true" multiValued="false"/>
  <copyField source="id" dest="id_int"/>
 
  <field name="fullrecord"      type="string"     indexed="false" stored="true" docValues="false"/>


### PR DESCRIPTION
Changes the delete procedure to, instead of actually deleting documents, puts an
empty document in its place.

Changes:
  * Added new solr field `deleted` of type `boolean` with a default of `false`
  * `bin/delete_ids` now adds a deleted document (with only `id` and `deleted=true`)
  * added dependency on gem `httpx`; `httpclient` is no longer supported and should be phased out.
  
