### PR TITLE
Add new ENV variable "HT_NO_EXTERNAL_DATA"

### DIFF
--- a/indexers/common.rb
+++ b/indexers/common.rb
@@ -36,12 +36,12 @@ extend Traject::UMichFormat::Macros
 require 'ht_traject/basic_macros'
 extend HathiTrust::BasicMacros
 
-if ENV["NO_DB"]
+if ENV["NO_DB"] or ENV["HT_NO_EXTERNAL_DATA"]
   require 'ht_traject/mock_oclc_resolution'
 else require 'ht_traject/oclc_resolution'
 end
 
-unless ENV['NO_REDIRECTS']
+if !(ENV['NO_REDIRECTS'] or ENV["HT_NO_EXTERNAL_DATA"])
   require 'ht_traject/redirects'
 end
 
@@ -70,7 +70,7 @@ each_record HathiTrust::Traject::Macros.setup
 
 to_field 'id', extract_marc('001', first: true)
 
-unless ENV['NO_REDIRECTS']
+unless ENV['NO_REDIRECTS'] or ENV["HT_NO_EXTERNAL_DATA"]
   to_field 'old_ids' do |_rec, acc, context|
     id = context.output_hash['id'].first
     acc.replace HathiTrust::Redirects.old_ids_for(id)

--- a/indexers/ht.rb
+++ b/indexers/ht.rb
@@ -5,7 +5,7 @@
 
 # Skip calling out to the print holdings database if I'm
 # on a machine that doesn't have access
-unless ENV['NO_DB']
+unless ENV['NO_DB'] or ENV["HT_NO_EXTERNAL_DATA"]
   each_record do |_r, context|
     context.clipboard[:ht][:items].fill_print_holdings! if context.clipboard[:ht][:has_items]
   end

--- a/lib/ht_traject/ht_item.rb
+++ b/lib/ht_traject/ht_item.rb
@@ -88,7 +88,7 @@ module HathiTrust
         @intl
       end
 
-      PH = if ENV['NO_DB']
+      PH = if ENV['NO_DB'] or ENV["HT_NO_EXTERNAL_DATA"]
              require_relative 'ht_mock_print_holdings'
              HathiTrust::MockPrintHoldings
            else


### PR DESCRIPTION
`HT_NO_EXTERNAL_DATA` is equivalent to setting
`NO_DB` and `NO_REDIRECTS` and can be used going forward
as a way to disallow any external data for testing
purposes.