### PR TITLE
Multiplatform example catalog build

### DIFF
--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -1,0 +1,36 @@
+---
+name: Build Catalog Sample Index
+
+on:
+  workflow_dispatch:
+
+# hathitrust/github_actions/build doesn't yet support multiplatform builds
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/hathitrust/catalog-solr-sample:latest
+          file: example-index/Dockerfile

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,31 @@
+Copyright (c) 2013-2022, Regents of the University of Michigan. All rights
+reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the name of the University of Michigan nor HathiTrust nor the names
+  of its contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE REGENTS OF THE UNIVERSITY OF MICHIGAN BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Sample HathiTrust catalog records (example-index/records-to-index.jsonl) are
+made available for development and testing purposes only, and are not intended
+for further re-use in other contexts.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ docker build . -f example-index/Dockerfile -t my-sample-solr
 and run e.g. `docker run -p 9033:9033 my-sample-solr`, or use in another
 `docker-compose.yml`, etc.
 
+To generate a multi-platform image, follow the instructions from https://docs.docker.com/build/building/multi-platform/ to get set up with multi-platform capability, then e.g.
+
+```
+docker buildx build --platform linux/amd64,linux/arm64 . -f example-index/Dockerfile -t ghcr.io/hathitrust/catalog-solr-sample:some-tag --push
+```
+
 ### Index one file into Solr
 
 Index a file of records without using the database or hardcoded filesystem paths:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Output will be in `debug.json`.
 
 This will build a docker image with a Solr core pre-loaded with a set of records.
 
-* As above, put records you want to load in `example-index/records-to-index.jsonl`
+* As above, put records you want to load in
+  `example-index/records-to-index.jsonl`. Some records are included with this
+repository; this is a set of 2,000 records from a variety of contributors that
+were updated in HathiTrust on May 1, 2022.
 
 * Then run:
 
@@ -50,11 +53,16 @@ docker build . -f example-index/Dockerfile -t my-sample-solr
 and run e.g. `docker run -p 9033:9033 my-sample-solr`, or use in another
 `docker-compose.yml`, etc.
 
-To generate a multi-platform image, follow the instructions from https://docs.docker.com/build/building/multi-platform/ to get set up with multi-platform capability, then e.g.
+A multi-platform (amd64/arm64) image with the sample records pre-loaded is
+available:
 
 ```
-docker buildx build --platform linux/amd64,linux/arm64 . -f example-index/Dockerfile -t ghcr.io/hathitrust/catalog-solr-sample:some-tag --push
+docker pull ghcr.io/hathitrust/catalog-solr-sample
 ```
+
+The sample HathiTrust catalog records are made available for development and
+testing purposes only, and are not intended for further re-use in other
+contexts.
 
 ### Index one file into Solr
 

--- a/example-index/Dockerfile
+++ b/example-index/Dockerfile
@@ -1,6 +1,6 @@
 # First, transform the MARC in JSON into Solr documents
 
-FROM jruby:9.3 AS traject
+FROM --platform=$BUILDPLATFORM jruby:9.3 AS traject
 
 ARG UNAME=app
 ARG UID=1000
@@ -33,7 +33,7 @@ ENV NO_DB 1
 # records-to-index.json should be in ./example-index
 RUN bin/tindex json example-index/records-to-index.jsonl
 
-FROM solr:8.11 AS indexer
+FROM --platform=$BUILDPLATFORM solr:8.11 AS indexer
 
 ENV SOLR_PORT=9033
 


### PR DESCRIPTION
The first two stages (traject and solr) run under the current build architecture, since the goal there is to produce a platform-independent solr index. The final stage creates an image based on the platform-specific solr image that includes the solr core generated in the previous stage.