### PR TITLE
Update README.md

### DIFF
--- a/solr/README.md
+++ b/solr/README.md
@@ -13,9 +13,11 @@ git pull origin main # get the new code
 touch /htsolr/catalog/flags/STOPCATALOGRELEASE 
 cd /htsolr/catalog/cores
 systemctl stop solr-current-catalog
-mv catalog "catalog_$(date %Y%m%d)"
+mv catalog "catalog_$(date +%Y%m%d)"
 # cd in there and rm core.properties
 cp -r /htsolr/catalog/bin/ht_catalog_indexer/solr/catalog .
+# You may need this on the new core so Solr can populate its contents
+chmod o+w /htsolr/catalog/cores/catalog
 systemctl start solr-current-catalog; sleep 10
 # Sanity check to see if it's up and returns a 200 (empty) set of documents
 curl 'http://localhost:9033/solr/catalog/select?q=*:*&wt=json' | json_xs
@@ -23,7 +25,7 @@ cd /htsolr/catalog/bin/ht_catalog_indexer
 /usr/bin/nohup bin/fullindex "logs/full_$(date +%Y%m%d).txt"
 # wait a few hours
 # point a catalog instance directly at beeftea-2 to make sure it works well
-rm -rf "/htsolr/catalog/cores/catalog_$(date %Y%m%d)"
+rm -rf "/htsolr/catalog/cores/catalog_$(date +%Y%m%d)"
 rm /htsolr/catalog/flags/STOPCATALOGRELEASE
 
 ```


### PR DESCRIPTION
- Two of the `date` commands were missing the "+" for the format.
- Add a suggested `chmod` command for the copied-in `catalog` core which fixed 500 errors. Maybe we should discuss if it seems like a bad idea.