### PR TITLE
Add new exactishSort type and use it

### DIFF
--- a/solr/catalog/conf/schema.xml
+++ b/solr/catalog/conf/schema.xml
@@ -272,9 +272,9 @@
  <field name="author_top"  type="text_nostem" indexed="true" stored="true"   multiValued="true" />
  <field name="author_rest" type="text_nostem" indexed="true" stored="true"   multiValued="true" />
  <field name="author2"     type="text_nostem" indexed="true" stored="true"   multiValued="true" />
- <field name="authorSort" type="exactish" indexed="true" stored="false" multiValued="false"/>
+ <field name="authorSort" type="exactishSort" indexed="true" stored="false" multiValued="false"/>
 
- <field name="author_sortkey"        type="exactish" indexed="true"  stored="true" multiValued="false"/>
+ <field name="author_sortkey"        type="exactishSort" indexed="true"  stored="true" multiValued="false"/>
 
 
  <copyField source="author" dest="authorStr"/>
@@ -282,7 +282,7 @@
 
  <!-- Title fields -->
 
- <field name="titleSort"        type="exactish" indexed="true"  stored="true" multiValued="false"/>
+ <field name="titleSort"        type="exactishSort" indexed="true"  stored="true" multiValued="false"/>
  <field name="title"            type="text"          indexed="true"  stored="true"  multiValued="true" termVectors="true" />
  <field name="title_l"          type="text_leftjustified" indexed="true" stored="false" multiValued="true" />
  <field name="vtitle"           type="string"        indexed="false" stored="true" multiValued="false" />
@@ -298,7 +298,7 @@
 
  <field name="title_ab_exact"    type="exactish"  indexed="true"  stored="false" multiValued="true"/>
 
- <field name="title_sortkey"        type="exactish" indexed="true"  stored="true" multiValued="false"/>
+ <field name="title_sortkey"        type="exactishSort" indexed="true"  stored="true" multiValued="false"/>
  <field name="title_display" type="string" indexed="false" stored="true" multiValued="false"/>
 
 

--- a/solr/catalog/conf/schema/exactish_char_substitution.txt
+++ b/solr/catalog/conf/schema/exactish_char_substitution.txt
@@ -1,0 +1,29 @@
+# NOTE THAT EVERYTHING IS LOWERCASE!
+# You'll want to put this BEFORE case folding
+
+
+# Stupid smart-quotes and MS Word characters
+# List pulled from https://stackoverflow.com/questions/2826191/converting-ms-word-curly-quotes-and-apostrophes
+
+"\u2013" => "-"
+"\u2014" => "-"
+"\u2015" => "-"
+
+"\u2017" => "_"
+
+"\u2018" => "'"
+"\u2019" => "'"
+"\u201b" => "'"
+"\u2032" => "'"
+
+"\u201a" => ","
+
+"\u201c" => "\""
+"\u201d" => "\""
+"\u201e" => "\""
+"\u2033" => "\""
+
+# Common punctuation substitutions
+
+"&" => " and "
+"@" => " at "

--- a/solr/catalog/conf/schema/text_types.xml
+++ b/solr/catalog/conf/schema/text_types.xml
@@ -83,6 +83,30 @@
 </analyzer>
 </fieldType>
 
+
+<!-- For sort keys, just want to downcase/normalize everything we can. Mostly copied from the
+ umich config. -->
+<fieldType name="exactishSort" class="solr.TextField" positionIncrementGap="&tpig;">
+<analyzer>
+  <charFilter class="solr.MappingCharFilterFactory" mapping="schema/exactish_char_substitution.txt"/>
+  <tokenizer class="solr.KeywordTokenizerFactory"/>
+  <filter class="solr.PatternReplaceFilterFactory" pattern="([:\-])" replacement=" " replace="all"/>
+  <filter class="solr.PatternReplaceFilterFactory" pattern="[\p{P}\p{Sm}\p{Sc}\p{So}]" replacement="" replace="all"/>
+  <filter class="solr.ICUFoldingFilterFactory"/>
+  <filter class="solr.CJKWidthFilterFactory"/>
+  <filter class="solr.DecimalDigitFilterFactory"/>
+  <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+
+  <!-- Left-pad numbers with zeroes -->
+  <filter class="solr.PatternReplaceFilterFactory" pattern="(\d+)" replacement="00000$1" replace="all"/>
+  <!-- Left-trim zeroes to produce 6 digit numbers -->
+  <filter class="solr.PatternReplaceFilterFactory" pattern="0*([0-9]{6,})" replacement="$1" replace="all"/>
+  <!-- squeeze multiple spaces to 1 -->
+  <filter class="solr.PatternReplaceFilterFactory" pattern="\s\s+" replacement=" " replace="all"/>
+</analyzer>
+</fieldType>
+
+
 <!-- a simple text type that only strips trailing punctuation, currently used for the author facet -->
 <fieldType name="textFacet" class="solr.TextField" sortMissingLast="true" omitNorms="true">
   <analyzer>


### PR DESCRIPTION
Adds a new `fieldType` called `exactishSort`, modeled on the one used in the umich config, and applies it to the title/author fields. 