### PR TITLE
Use mlibrary/canister 0.9.2 to try and mitigate threading issues.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   build-essential \
+  git \
   netbase \
   netcat
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   build-essential \
-  git \
   netbase \
   netcat
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 gem "semantic_logger"
 gem "http", "~>5.0"
-gem "canister"
+gem "canister", "~> 0.9.2", github: "mlibrary/canister"
 gem "date_named_file"
 gem "dotenv"
 gem "httpclient"

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 gem "semantic_logger"
 gem "http", "~>5.0"
-gem "canister", "~> 0.9.2", github: "mlibrary/canister"
+gem "canister", "~> 0.9.2"
 gem "date_named_file"
 gem "dotenv"
 gem "httpclient"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/mlibrary/canister.git
-  revision: f2013b74c27e5b5cfe01dd3677ff670a2698bde5
-  specs:
-    canister (0.9.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -11,6 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     builder (3.2.4)
+    canister (0.9.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     date_named_file (0.1.1)
@@ -167,7 +162,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  canister (~> 0.9.2)!
+  canister (~> 0.9.2)
   date_named_file
   dotenv
   http (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/mlibrary/canister.git
+  revision: f2013b74c27e5b5cfe01dd3677ff670a2698bde5
+  specs:
+    canister (0.9.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -5,7 +11,6 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     builder (3.2.4)
-    canister (0.9.1)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     date_named_file (0.1.1)
@@ -162,7 +167,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  canister
+  canister (~> 0.9.2)!
   date_named_file
   dotenv
   http (~> 5.0)


### PR DESCRIPTION
- For now use GitHub for the gem since rubygems.org doesn't have the new version.
- This introduces a dependency on git in the main Dockerfile.
- Should go back to using rubygems at a later date.