### PR TITLE
DEV-940/DEV-955 - simplify canister usage

### DIFF
--- a/lib/ht_traject/mock_redirects.rb
+++ b/lib/ht_traject/mock_redirects.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'zinzout'
+require_relative "../services"
+
+# Redirect file is .txt.gz file with each line in the format
+# "old_cid\tnew_cid"
+#
+# The example file contains the line "000004165	006215998" (old, new) so
+# redirects["006215998"] -> ["000004165"]
+
+module HathiTrust
+  class MockRedirects
+    def old_ids_for(id)
+      []
+    end
+
+    def load
+    end
+  end
+end

--- a/lib/ht_traject/redirects.rb
+++ b/lib/ht_traject/redirects.rb
@@ -15,6 +15,13 @@ module HathiTrust
       redirects[id] || []
     end
 
+    def load
+      if !@redirects
+        Services[:logger].info("Loading redirects from #{Services[:redirect_file]}")
+        redirects
+      end
+    end
+
     private
 
     def redirects

--- a/lib/ht_traject/redirects.rb
+++ b/lib/ht_traject/redirects.rb
@@ -15,10 +15,6 @@ module HathiTrust
       redirects[id] || []
     end
 
-    def exist?
-      File.readable? Services[:redirect_file]
-    end
-
     private
 
     def redirects

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -6,6 +6,7 @@ require "sequel"
 
 require_relative "cictl/solr_client"
 require_relative "ht_traject/redirects"
+require_relative "ht_traject/mock_redirects"
 require_relative "ht_traject/ht_mock_print_holdings"
 require_relative "ht_traject/ht_print_holdings"
 require_relative "ht_traject/mock_oclc_resolution"

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -79,27 +79,18 @@ module HathiTrust
     useTimezone=true&serverTimezone=UTC"
   end
 
-  Services.register(:no_db?) do
-    ENV["NO_DB"] == "1" or Services[:no_external_data?]
-  end
-
-  Services.register(:no_external_data?) do
-    ENV["HT_NO_EXTERNAL_DATA"] == "1"
-  end
-
-  Services.register(:no_redirects?) do
-    ENV["NO_REDIRECTS"] == "1" or Services[:no_external_data?]
-  end
+  Services.register(:no_db?) { ENV["NO_DB"] || ENV["NO_EXTERNAL_DATA"] }
+  Services.register(:no_redirects?) { ENV["NO_REDIRECTS"] || ENV["NO_EXTERNAL_DATA"] }
 
   Services.register(:print_holdings) do
-    HathiTrust.const_get(Services[:no_db?] ? :MockPrintHoldings : :PrintHoldings)
+    Services[:no_db?] ? MockPrintHoldings : PrintHoldings
   end
 
   Services.register(:oclc_resolution) do
-    HathiTrust.const_get(Services[:no_db?] ? :MockOCLCResolution : :OCLCResolution)
+    Services[:no_db?] ? MockOCLCResolution : OCLCResolution
   end
 
   Services.register(:redirects) do
-    HathiTrust.const_get(Services[:no_redirects?] ? :MockRedirects : :Redirects).new
+    Services[:no_redirects?] ? MockRedirects.new : Redirects.new
   end
 end

--- a/spec/cictl/deleted_records_spec.rb
+++ b/spec/cictl/deleted_records_spec.rb
@@ -4,12 +4,7 @@ require "spec_helper"
 require "zinzout"
 
 RSpec.describe CICTL::DeletedRecords do
-  around(:each) do |ex|
-    @original_data_dir = HathiTrust::Services[:data_directory]
-    HathiTrust::Services.register(:data_directory) { Dir.mktmpdir }
-    ex.run
-    HathiTrust::Services.register(:data_directory) { @original_data_dir }
-  end
+  override_service(:data_directory) { Dir.mktmpdir }
 
   it "gets something for today's file" do
     expect(described_class.daily_file.to_s).to match(/deleted_records/)

--- a/spec/cictl/index_command_spec.rb
+++ b/spec/cictl/index_command_spec.rb
@@ -33,7 +33,29 @@ RSpec.describe CICTL::IndexCommand do
       it "bails out" do
         expect {
           CICTL::Commands.start(["index", "all", "--no-wait", "--quiet", "--log", test_log])
-        }.to raise_error(Errno::ENOENT)
+        }.to raise_error(CICTL::CICTLError)
+      end
+
+      it "does not touch the index" do
+        pre_run_solr_count = solr_count
+
+        begin
+          CICTL::Commands.start(["index", "all", "--no-wait", "--quiet", "--log", test_log])
+        rescue CICTL::CICTLError
+        end
+
+        expect(solr_count).to eq pre_run_solr_count
+      end
+    end
+
+    context "without using redirect file" do
+      override_service(:redirect_file) { "no_such_redirects_file.gz.txt" }
+      override_service(:no_redirects?) { true }
+
+      it "runs to completion" do
+        expect {
+          CICTL::Commands.start(["index", "all", "--no-wait", "--quiet", "--log", test_log])
+        }.not_to raise_error
       end
     end
   end

--- a/spec/cictl/index_command_spec.rb
+++ b/spec/cictl/index_command_spec.rb
@@ -26,23 +26,15 @@ RSpec.describe CICTL::IndexCommand do
       expect(solr_ids("deleted:true")).to include(bogus_delete)
     end
 
-    it "bails out if redirects file can't be found" do
-      # Would be nice if we could class_double Services, but alas that would require
-      # patching various parameters to :[] and there are plenty of them.
-      @save_redirect_file = HathiTrust::Services[:redirect_file]
-      @save_no_redirects = HathiTrust::Services[:no_redirects?]
-      @save_no_external_data = HathiTrust::Services[:no_external_data?]
-      @save_redirects = HathiTrust::Services[:redirects]
-      HathiTrust::Services.register(:redirect_file) { "no_such_redirects_file.gz.txt" }
-      HathiTrust::Services.register(:no_redirects?) { false }
-      HathiTrust::Services.register(:no_external_data?) { false }
-      expect {
-        CICTL::Commands.start(["index", "all", "--no-wait", "--quiet", "--log", test_log])
-      }.to raise_error(CICTL::CICTLError)
-      HathiTrust::Services.register(:redirect_file) { @save_redirect_file }
-      HathiTrust::Services.register(:no_redirects?) { @save_no_redirects }
-      HathiTrust::Services.register(:no_external_data?) { @save_no_external_data }
-      HathiTrust::Services.register(:redirects) { @save_redirects }
+    context "using nonexistent redirect file" do
+      override_service(:redirect_file) { "no_such_redirects_file.gz.txt" }
+      override_service(:no_redirects?) { false }
+
+      it "bails out" do
+        expect {
+          CICTL::Commands.start(["index", "all", "--no-wait", "--quiet", "--log", test_log])
+        }.to raise_error(Errno::ENOENT)
+      end
     end
   end
 
@@ -120,13 +112,17 @@ RSpec.describe CICTL::IndexCommand do
   end
 
   describe "#index today" do
+    # Create new update and delete files in a temp directory based on fixtures.
+    after(:each) { HathiTrust::Services.register(:data_directory) { @save_dd } }
+
     # Note that "today" means "index today, using the file dated yesterday"
     it "indexes 'today' and produces deletes file" do
       update_source = CICTL::ZephirFile.update_files.last
       del_source = CICTL::ZephirFile.delete_files.last
-      # Create new update and delete files in a temp directory based on fixtures.
-      save_dd = HathiTrust::Services[:data_directory]
+
+      @save_dd = HathiTrust::Services[:data_directory]
       HathiTrust::Services.register(:data_directory) { Dir.mktmpdir }
+
       zyesterday = CICTL::ZephirFile.update_files.yesterday
       delyesterday = CICTL::ZephirFile.delete_files.yesterday
 
@@ -143,8 +139,6 @@ RSpec.describe CICTL::IndexCommand do
       expect(solr_count).to eq(zcount + delcount)
       expect(CICTL::DeletedRecords.daily_file.readable?)
       expect(Zinzout.zin(CICTL::DeletedRecords.daily_file).count).to eq(delcount)
-
-      HathiTrust::Services.register(:data_directory) { save_dd }
     end
   end
 end

--- a/spec/cictl/solr_command_spec.rb
+++ b/spec/cictl/solr_command_spec.rb
@@ -9,11 +9,12 @@ RSpec.describe CICTL::SolrCommand, :livesolr do
       expect { CICTL::Commands.start(["solr", "ping"]) }.to output(/SUCCESS/).to_stdout
     end
 
-    it "fails to ping a fake solr url" do
-      old_solr_url = HathiTrust::Services[:solr_url]
-      HathiTrust::Services.register(:solr_url) { "http://solr-sdr-catalog:1111/solr/catalog" }
-      expect { CICTL::Commands.start(["solr", "ping"]) }.to output(/FAILURE/).to_stdout
-      HathiTrust::Services.register(:solr_url) { old_solr_url }
+    context "with fake solr url" do
+      override_service(:solr_url) { "http://solr-sdr-catalog:1111/solr/catalog" }
+
+      it "fails to ping" do
+        expect { CICTL::Commands.start(["solr", "ping"]) }.to output(/FAILURE/).to_stdout
+      end
     end
   end
 

--- a/spec/ht_traject/redirects_spec.rb
+++ b/spec/ht_traject/redirects_spec.rb
@@ -3,45 +3,28 @@
 require "spec_helper"
 
 RSpec.describe HathiTrust::Redirects do
-  before do
-    @real_data_directory = HathiTrust::Services[:data_directory]
-  end
-
-  let(:real_file) { File.join(@real_data_directory, CICTL::Examples.redirects_file) }
-  let(:no_file) { File.join(@real_data_directory, "no_such_redirects_file.txt.gz") }
   # The example file contains the line "000004165	006215998" (old, new) so
   # redirects["006215998"] -> ["000004165"]
   let(:sample_old_cid) { "000004165" }
   let(:sample_new_cid) { "006215998" }
-  let(:services_double) { class_double("HathiTrust::Services").as_stubbed_const }
-
-  describe "#exist?" do
-    context "with a real file" do
-      it "returns true" do
-        allow(services_double).to receive(:[]).with(:redirect_file).and_return(real_file)
-        expect(described_class.new.exist?).to eq true
-      end
-    end
-
-    context "with a nonexistent file" do
-      it "returns false" do
-        allow(services_double).to receive(:[]).with(:redirect_file).and_return(no_file)
-        expect(described_class.new.exist?).to eq false
-      end
-    end
-  end
 
   describe "#old_ids_for" do
     context "with a real file" do
+      override_service(:redirect_file) do
+        File.join(HathiTrust::Services[:data_directory], CICTL::Examples.redirects_file)
+      end
+
       it "returns the old CID" do
-        allow(services_double).to receive(:[]).with(:redirect_file).and_return(real_file)
         expect(described_class.new.old_ids_for(sample_new_cid)).to eq([sample_old_cid])
       end
     end
 
     context "with a nonexistent file" do
+      override_service(:redirect_file) do
+        File.join(HathiTrust::Services[:data_directory], "no_such_redirects_file.txt.gz")
+      end
+
       it "raises error" do
-        allow(services_double).to receive(:[]).with(:redirect_file).and_return(no_file)
         expect { described_class.new.old_ids_for(sample_new_cid) }.to raise_error(Errno::ENOENT)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -139,3 +139,12 @@ def solr_ids(q = "*:*")
   response = CICTL::SolrClient.new.get("select", params: solr_params)
   response["response"]["docs"].map { |doc| doc["id"] }
 end
+
+def override_service(key, &block)
+  around(:each) do |example|
+    old_val = HathiTrust::Services[key]
+    HathiTrust::Services.register(key, &block)
+    example.run
+    HathiTrust::Services.register(key) { old_val }
+  end
+end


### PR DESCRIPTION
- remove preflight check for redirects file
- add helper for overriding services in tests

Tests pass for me with no stack issues. I did occasionally see the stack issues in the process of cleaning this up, but not with respect to the redirects file not being found. I suspect it might have been happening when something in `Services` was overridden, but the test failed and the original value wasn't restored. Using the provided `override_service` test helper should avoid that (i.e. the original value will be restored even if the test raises an exception)

@moseshll Assuming you're good with this, I'm good with the other branch then being merged to main.