### PR TITLE
DEV-627: "since" uses filenames embedded in date

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,12 @@ Solr should be reachable via the `solr-sdr-catalog` hostname.
 ### Indexing
 
 Note that "today's file" is "the file that became available today", which 
-will have _yesterday's_ date embedded in it. If you use these scripts you 
-don't have to worry about any off-by-one errors. 
+will have _yesterday's_ date embedded in it.
 
-Re-run today's file: 
+Re-process today's file: 
 * `bin/cictl index today`
 
-Run all the update files since a given date (YYYYMMDD):
+Processes all deletes/marcfiles with a date on or after YYYYMMDD in its name sequentially
 * `bin/cictl index since 20220302`
 
 Re-build the entire index based on the last full file, making sure 

--- a/lib/cictl/common.rb
+++ b/lib/cictl/common.rb
@@ -31,14 +31,16 @@ module CICTL
 
     # Coerce a user-supplied Date or String to a Date within a block.
     def with_date(obj)
-      date = obj
-      unless obj.is_a? Date
+      date = if obj.respond_to?(:to_date)
+        obj.to_date
+      else
         begin
-          date = Date.parse(obj.to_s)
+          Date.parse(obj.to_s)
         rescue => e
           raise CICTLError.new "unable to parse \"#{obj}\" (#{e})"
         end
       end
+
       yield date
     end
   end

--- a/lib/cictl/index_command.rb
+++ b/lib/cictl/index_command.rb
@@ -47,7 +47,7 @@ module CICTL
       solr_client.commit! if options[:commit]
     end
 
-    desc "date YYYYMMDD", "Process the delete and index files timestamped YYYYMMDD"
+    desc "date YYYYMMDD", "Process the delete and index files with the date YYYYMMDD in its name"
     def date(date)
       preflight
       with_date(date) do |date|
@@ -56,16 +56,11 @@ module CICTL
       end
     end
 
-    desc "since YYYYMMDD", "Run all deletes/marcfiles in order since the given date"
+    desc "since YYYYMMDD", "Processes all deletes/marcfiles with a date on or after YYYYMMDD in its name in order"
     def since(date)
-      with_date(date) do |date|
+      with_date(date) do |start_date|
         yesterday = Date.today - 1
-        begin
-          start_date = date - 1
-        rescue Date::Error => e
-          fatal e.message
-        end
-        logger.debug "index since(#{date}): #{start_date} to #{yesterday}"
+        logger.debug "index since(#{start_date}): #{start_date} to #{yesterday}"
         (start_date..yesterday).each do |index_date|
           logger.info("\n------- #{index_date} -----------\n")
           call_date_command index_date
@@ -73,7 +68,7 @@ module CICTL
       end
     end
 
-    desc "today", "Run the catchup (delete and index) for last night's files"
+    desc "today", "Process the catchup (delete and index) for last night's files"
     def today
       # HT's "today" file is dated yesterday
       yesterday = (Date.today - 1).strftime("%Y%m%d")


### PR DESCRIPTION
Catalog file names are named using the day before they were produced, as is noted in the README.

When we did the "full" index, this calls the `since` command which was intended to process all incremental files starting with the one produced on the same date as the full file up to the one produced on the current date.

However, `since` was subtracting a day from the start date, since its argument reflected the day the file was produced rather than the date in its name.

This PR makes handling for all commands taking dates consistent and updates the documentation to reflect that.