### PR TITLE
Dockerfile updates for traject

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,30 @@
-FROM jruby:9.4-jdk17
+FROM jruby:9.4-jdk17 AS base
 ARG UNAME=app
 ARG UID=1000
 ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   build-essential \
-  netbase \
-  netcat
+  netbase
 
-RUN groupadd -g ${GID} -o ${UNAME}
-RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash ${UNAME}
-RUN mkdir -p /gems && chown ${UID}:${GID} /gems
-
-# COPY --chown=${UID}:${GID} Gemfile* /app/
 WORKDIR /app
-RUN wget -O /usr/local/bin/wait-for https://github.com/eficode/wait-for/releases/download/v2.2.3/wait-for && chmod +x /usr/local/bin/wait-for
 
 # USER $UNAME
 ENV BUNDLE_PATH /gems
 RUN gem install bundler
+
+FROM base AS development
+
+FROM base AS production
+
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -d /app -u $UID -g $GID -o -s /bin/bash $UNAME
+RUN mkdir -p /gems && chown $UID:$GID /gems
+USER $UNAME
+COPY --chown=$UID:$GID Gemfile* /app
+WORKDIR /app
+ENV BUNDLE_PATH /gems
+RUN bundle install
+COPY --chown=$UID:$GID . /app
+
+LABEL org.opencontainers.image.source="https://github.com/hathitrust/hathitrust_catalog_indexer"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ docker-compose up -d solr-sdr-catalog
 docker-compose run --rm traject bundle install
 ```
 
+The contents of `lib/translation_maps/ht/collection_code_to_original_from.yaml` will change
+depending on the contents of the sample database you are running locally. To keep `git` from
+bugging you about this constantly-drifting-from-upstream file, run
+```
+git update-index --skip-worktree lib/translation_maps/ht/collection_code_to_original_from.yaml
+```
+and to undo this (like if you update the file based on the production database and want the
+repo up-to-date) run
+```
+git update-index --no-skip-worktree lib/translation_maps/ht/collection_code_to_original_from.yaml
+```
+
 ### Generate Solr documents
 
 Generate Solr documents given an input file of MARC records in JSON format, one per line:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,19 @@
 ---
 
+x-condition-healthy: &healthy
+  condition: service_healthy
+
+x-healthcheck-defaults: &healthcheck-defaults
+  interval: 5s
+  timeout: 10s
+  start_period: 10s
+  retries: 5
+
 services:
   traject:
-    build: .
+    build: 
+      context: .
+      target: development
     volumes:
       - .:/app
       - gem_cache:/gems
@@ -10,29 +21,40 @@ services:
       - SOLR_URL=http://solr-sdr-catalog:9033/solr/catalog
       - redirect_file=/dev/null
       - NO_DB=1
+    network_mode: host
+    command: sleep infinity
 
   test:
-    build: .
+    build: 
+      context: .
+      target: development
     volumes:
       - .:/app
       - gem_cache:/gems
-    command: bash -c "wait-for solr-sdr-catalog:9033 mariadb:3306 && JRUBY_OPTS='--debug' bundle exec rspec"
+    command: bundle exec rspec
     environment:
+      - JRUBY_OPTS=--debug
       - SOLR_URL=http://solr-sdr-catalog:9033/solr/catalog
       - redirect_file=/dev/null
     depends_on:
-      - solr-sdr-catalog
-      - mariadb
+      solr-sdr-catalog: *healthy
+      mariadb: *healthy
 
   solr-sdr-catalog:
     build: solr
     ports:
       - "9033:9033"
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: [ "CMD", "curl","-s","-f","http://localhost:9033/solr/catalog/admin/ping" ]
 
   mariadb:
     image: ghcr.io/hathitrust/db-image:latest
     ports:
       - "3306:3306"
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: [ "CMD", "healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized" ]
 
 volumes:
   gem_cache:

--- a/lib/translation_maps/ht/collection_code_to_original_from.yaml
+++ b/lib/translation_maps/ht/collection_code_to_original_from.yaml
@@ -1,16 +1,18 @@
----
 aeu: University of Alberta
 aubru: The University of Queensland
 aztes: Arizona State University
 chi: University of Chicago
 coo: Cornell University
+cou: University of Colorado Boulder
 ctu: University of Connecticut
 deu: University of Delaware
 fmu: University of Miami
 geu: Emory University
 gri: Getty Research Institute
+gu: University System of Georgia
 gwla: Technical Report Archive &amp; Image Library
 hvd: Harvard University
+iagg: Grinnell College
 iau: University of Iowa
 ibc: Boston College
 iduke: Duke University
@@ -27,8 +29,8 @@ iucla: University of California
 iufl: State University System of Florida
 iuiuc: University of Illinois at Urbana-Champaign
 iunc: University of North Carolina at Chapel Hill
-keio: 慶應義塾大学 (Keio University)
-lebau: American University of Beirut
+keio: Keio University 慶應義塾大学
+lebau: American University of Beirut - الجامعة الأميركيّة في بيروت
 mdbj: Johns Hopkins University
 mdl: Minnesota Digital Library
 mdu: University of Maryland, College Park
@@ -42,11 +44,14 @@ nbb: Brooklyn Museum
 nbuu: University At Buffalo, The State University of New York
 ncwsw: Wake Forest University
 njp: Princeton University
+njpt: Princeton Theological Seminary
+njr: Rutgers University
 nnc: Columbia University
 nnfr: The Frick Collection
 nrlf: University of California
 nwu: Northwestern University
 nyp: New York Public Library
+oclw: Case Western Reserve University
 oks: Oklahoma State University
 osu: The Ohio State University
 phc: Haverford College
@@ -54,13 +59,14 @@ ppt: Temple University
 pst: Pennsylvania State University
 pu: University of Pennsylvania
 pur: Purdue University
+purd: Purdue University
 qmm: McGill University
 scu: University of South Carolina
 srlf: University of California
 tu: University of Tennessee, Knoxville
 txcm: Texas A&amp;M University
 txsmtsu: Texas State University - San Marcos
-txu: University of Texas at Austin
+txu: The University of Texas
 ucbk: University of California
 ucd: University of California
 uci: University of California

--- a/lib/translation_maps/ht/collection_code_to_original_from.yaml
+++ b/lib/translation_maps/ht/collection_code_to_original_from.yaml
@@ -4,16 +4,13 @@ aubru: The University of Queensland
 aztes: Arizona State University
 chi: University of Chicago
 coo: Cornell University
-cou: University of Colorado Boulder
 ctu: University of Connecticut
 deu: University of Delaware
 fmu: University of Miami
 geu: Emory University
 gri: Getty Research Institute
-gu: University System of Georgia
 gwla: Technical Report Archive &amp; Image Library
 hvd: Harvard University
-iagg: Grinnell College
 iau: University of Iowa
 ibc: Boston College
 iduke: Duke University
@@ -30,8 +27,8 @@ iucla: University of California
 iufl: State University System of Florida
 iuiuc: University of Illinois at Urbana-Champaign
 iunc: University of North Carolina at Chapel Hill
-keio: 'Keio University 慶應義塾大学 '
-lebau: American University of Beirut - الجامعة الأميركيّة في بيروت
+keio: 慶應義塾大学 (Keio University)
+lebau: American University of Beirut
 mdbj: Johns Hopkins University
 mdl: Minnesota Digital Library
 mdu: University of Maryland, College Park
@@ -45,8 +42,6 @@ nbb: Brooklyn Museum
 nbuu: University At Buffalo, The State University of New York
 ncwsw: Wake Forest University
 njp: Princeton University
-njpt: Princeton Theological Seminary
-njr: Rutgers University
 nnc: Columbia University
 nnfr: The Frick Collection
 nrlf: University of California
@@ -65,7 +60,7 @@ srlf: University of California
 tu: University of Tennessee, Knoxville
 txcm: Texas A&amp;M University
 txsmtsu: Texas State University - San Marcos
-txu: The University of Texas
+txu: University of Texas at Austin
 ucbk: University of California
 ucd: University of California
 uci: University of California


### PR DESCRIPTION
Brings our dockerfile up to current standards & allows building an image we can use in kubernetes for catalog indexing

* remove wait-for & use health checks
* use production stage
