### PR TITLE
Attempt to fix auth issue for batch client

### DIFF
--- a/lib/cictl/solr_client.rb
+++ b/lib/cictl/solr_client.rb
@@ -67,6 +67,7 @@ module CICTL
           builder.request :url_encoded
           builder.response :json
           builder.adapter :httpx
+          builder.headers = connection.headers
           builder.headers["Content-Type"] = "application/json"
         end
     end


### PR DESCRIPTION
This copies the authentication headers from the existing RSolr setup. Without this, the `post` ends up failing even with credentials in the URL. Not sure why, or if there's a better way to fix it -- I didn't dig into Faraday enough to figure that out.