### PR TITLE
51 collection map should use database

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,6 @@ docker-compose up -d solr-sdr-catalog
 docker-compose run --rm traject bundle install
 ```
 
-The contents of `lib/translation_maps/ht/collection_code_to_original_from.yaml` will change
-depending on the contents of the sample database you are running locally. To keep `git` from
-bugging you about this constantly-drifting-from-upstream file, run
-```
-git update-index --skip-worktree lib/translation_maps/ht/collection_code_to_original_from.yaml
-```
-and to undo this (like if you update the file based on the production database and want the
-repo up-to-date) run
-```
-git update-index --no-skip-worktree lib/translation_maps/ht/collection_code_to_original_from.yaml
-```
-
 ### Generate Solr documents
 
 Generate Solr documents given an input file of MARC records in JSON format, one per line:

--- a/indexers/common_ht.rb
+++ b/indexers/common_ht.rb
@@ -1,3 +1,6 @@
+$:.unshift "#{File.dirname(__FILE__)}/../lib"
+require "services"
+
 #################################
 # COMMON HT STUFF
 #################################
@@ -68,7 +71,7 @@ to_field 'ht_rightscode' do |_record, acc, context|
 end
 
 to_field 'htsource' do |_record, acc, context|
-  cc_to_of = Traject::TranslationMap.new('ht/collection_code_to_original_from')
+  cc_to_of = HathiTrust::Services[:collection_map]
   if context.clipboard[:ht][:has_items]
     acc.concat context.clipboard[:ht][:items].collection_codes.map { |x| cc_to_of[x] }
   end

--- a/lib/cictl/collection_map.rb
+++ b/lib/cictl/collection_map.rb
@@ -4,6 +4,17 @@ require_relative "../services"
 
 module CICTL
   class CollectionMap
+    # The main purpose of this class is to provide a Traject::TranslationMap.
+    # Reads from YAML file or database depending on whether we're using the database
+    # (which in almost all cases we will be).
+    def to_translation_map(no_db: HathiTrust::Services[:no_db?])
+      Traject::TranslationMap.new(no_db ? "ht/collection_code_to_original_from" : collection_map)
+    end
+
+    private
+
+    # Returns a Hash that can, if necessary, be sent #.to_yaml
+    # to update the `ht/collection_code_to_original_from.yaml` file.
     def collection_map
       @collection_map ||= begin
         sql = <<~SQL
@@ -17,10 +28,6 @@ module CICTL
         end
         ccof
       end
-    end
-
-    def to_yaml
-      collection_map.to_yaml
     end
   end
 end

--- a/lib/cictl/indexer.rb
+++ b/lib/cictl/indexer.rb
@@ -33,7 +33,6 @@ module CICTL
       fatal "Can't find reader #{reader_path}" unless File.exist?(reader_path)
       fatal "Can't find writer #{writer_path}" unless File.exist?(writer_path)
       logger.debug "reader: #{reader_path}; writer: #{writer_path}"
-      update_collection_map
       call_indexer marcfile
     end
 
@@ -76,15 +75,6 @@ module CICTL
         File.join(home, default_dir, custom_file),
         File.join(home, default_dir, custom_file + ".rb")
       ].find { |path| File.exist? path } || fatal("Unable to find requested config file #{custom_file}")
-    end
-
-    def update_collection_map
-      return if HathiTrust::Services[:no_db?]
-
-      logger.info "updating collection map"
-      File.open(File.join(collection_map_directory, COLLECTION_MAP_FILE), "w:utf-8") do |f|
-        f.puts CollectionMap.new.to_yaml
-      end
     end
 
     def collection_map_directory

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -100,4 +100,8 @@ module HathiTrust
   Services.register(:redirects) do
     Services[:no_redirects?] ? MockRedirects.new : Redirects.new
   end
+
+  Services.register(:collection_map) do
+    CICTL::CollectionMap.new.to_translation_map
+  end
 end

--- a/spec/cictl/collection_map_spec.rb
+++ b/spec/cictl/collection_map_spec.rb
@@ -1,18 +1,25 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "yaml"
 
 RSpec.describe CICTL::CollectionMap do
-  describe "#collection_map" do
+  RSpec.shared_examples "translation map" do |map|
+    it "is Traject::TranslationMap" do
+      expect(map).to be_kind_of(Traject::TranslationMap)
+    end
+
     it "contains a value we expect" do
-      expect(described_class.new.collection_map).to have_key("miu")
+      expect(map["miu"]).to eq("University of Michigan")
     end
   end
 
-  describe "#to_yaml" do
-    it "returns parseable YAML" do
-      expect { YAML.parse(described_class.new.to_yaml) }.not_to raise_error
+  describe "#to_translation_map" do
+    context "with no_db flag unset (typical case)" do
+      it_behaves_like "translation map", described_class.new.to_translation_map(no_db: false)
+    end
+
+    context "with no_db flag set (atypical case)" do
+      it_behaves_like "translation map", described_class.new.to_translation_map(no_db: true)
     end
   end
 end


### PR DESCRIPTION
Addresses #51 
aka DEV-1424 catalog indexer error writing collection map YAML
- Indexer no longer writes `lib/translation_maps/ht/collection_code_to_original_from.yaml`
- `CollectionMap` is now responsible for returning `Traject::TranslationMap` based on DB or existing YAML
- Traject indexing innards calls on `Services` for the map instead of loading YAML
- Remove instructions for janky workaround since collection_code_to_original_from.yaml should no longer be in constant flux