### PR TITLE
DEV-1440 - write journal when indexing full file

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -104,4 +104,6 @@ module HathiTrust
   Services.register(:collection_map) do
     CICTL::CollectionMap.new.to_translation_map
   end
+
+  Services.register(:job_name) { ENV.fetch("JOB_NAME", $PROGRAM_NAME) }
 end

--- a/spec/cictl/index_command_spec.rb
+++ b/spec/cictl/index_command_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe CICTL::IndexCommand do
   describe "#index continue" do
     context "with no journal" do
       it "indexes all example records" do
-        update_file_count = CICTL::Examples.of_type(:upd).count
+        file_count = CICTL::Examples.of_type(:full, :upd).count
         CICTL::Commands.start(["index", "continue", "--quiet", "--log", test_log])
         expect(solr_count).to eq CICTL::Examples.all_ids.count
-        expect(Dir.children(HathiTrust::Services[:journal_directory]).count).to eq(update_file_count)
+        expect(Dir.children(HathiTrust::Services[:journal_directory]).count).to eq(file_count)
         expect(metrics?).to eq true
       end
     end


### PR DESCRIPTION
We were checking for a full journal file but not writing one when we did the full index, leading to a situation where regardless of journal file presence the "continue" command would do a full reindex every day.

This refactors the `all` command some, and tests that we are writing both the full and update journal files.