### PR TITLE
DEV-973: check correct journal file for continue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 
 # USER $UNAME
 ENV BUNDLE_PATH /gems
-RUN gem install bundler
+RUN gem install bundler --version "~> 2.5.23"
 
 FROM base AS development
 

--- a/lib/cictl/index_command.rb
+++ b/lib/cictl/index_command.rb
@@ -24,7 +24,7 @@ module CICTL
       # If there is a missing journal, start indexing from that point.
       else
         (last_full.to_datetime.to_date..(Date.today - 1)).each do |date|
-          journal = Journal.new(date: last_full.to_datetime.to_date, full: false)
+          journal = Journal.new(date: date, full: false)
           if journal.missing?
             logger.info "missing update journal #{journal}, calling `cictl since #{journal.date}`"
             call_since_command(journal.date)

--- a/spec/cictl/index_command_spec.rb
+++ b/spec/cictl/index_command_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe CICTL::IndexCommand do
     it "indexes full records and deleted record from example date" do
       examples = CICTL::Examples.for_date("20230103")
       CICTL::Commands.start(["index", "date", "20230103", "--log", test_log])
-      expect(solr_count).to eq examples.map { |ex| ex[:ids] }.flatten.uniq.count
+      expect(solr_count).to eq unique_id_count(examples)
       expect(File.exist?(CICTL::Journal.new(date: Date.new(2023, 1, 3)).path)).to eq(true)
       expect(metrics?).to eq true
     end


### PR DESCRIPTION
`cictl index continue` was checking only that the full journal existed (and checking that multiple times)... This should correct the observed behavior where it is not indexing additional daily files after doing the full run.