### PR TITLE
- Update to push_metrics 0.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/hathitrust/push_metrics
-  revision: cc7ca6b6c65130335e933f5686f60a82ba1c97c7
+  revision: 3cba728a95eb936fed5f06da028c88d06bb23996
   specs:
-    push_metrics (0.9.1)
+    push_metrics (0.10.0)
       milemarker (~> 1.0)
       prometheus-client (~> 4.0)
 

--- a/spec/cictl/index_command_spec.rb
+++ b/spec/cictl/index_command_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe CICTL::IndexCommand do
 
   around(:each) do |example|
     job_name = HathiTrust::Services[:job_name]
-    Faraday.delete("#{ENV["PUSHGATEWAY"]}/metrics/job/#{job_name}")
+    # Trailing slash on URL is needed because we are matching instance with blank name
+    Faraday.delete("#{ENV["PUSHGATEWAY"]}/metrics/job/#{job_name}/instance/")
     with_test_environment do |tmpdir|
       example.run
     end


### PR DESCRIPTION
- Modify Faraday delete call to remove the (blank) instance/JOB_NAMESPACE
  - See https://github.com/prometheus/pushgateway/issues/225