### PR TITLE
DEV-1475 catalog indexing: update what env vars it uses for the database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       - gem_cache:/gems
     environment:
       - SOLR_URL=http://solr-sdr-catalog:9033/solr/catalog
-      - redirect_file=/dev/null
-      - NO_DB=1
+      - REDIRECT_FILE=/dev/null
+      #- NO_DB=1
     network_mode: host
     command: sleep infinity
 
@@ -37,6 +37,10 @@ services:
       - PUSHGATEWAY=http://pushgateway:9091
       - REDIRECT_FILE=/dev/null
       - SOLR_URL=http://solr-sdr-catalog:9033/solr/catalog
+      - MARIADB_HT_RO_USERNAME=ht_rights
+      - MARIADB_HT_RO_PASSWORD=ht_rights
+      - MARIADB_HT_RO_HOST=mariadb
+      - MARIADB_HT_RO_DATABASE=ht
     depends_on:
       pushgateway: *healthy
       mariadb: *healthy
@@ -54,6 +58,14 @@ services:
     image: ghcr.io/hathitrust/db-image:latest
     ports:
       - "3306:3306"
+    environment:
+      # setting via MYSQL_ROOT_PASSWORD didn't work; this at least
+      # makes it clear that we have to dig out its generated root password
+      # from its startup
+      MYSQL_RANDOM_ROOT_PASSWORD: 1
+      MYSQL_DATABASE: ht
+      MYSQL_USER: ht_rights
+      MYSQL_PASSWORD: ht_rights
     healthcheck:
       <<: *healthcheck-defaults
       test: [ "CMD", "healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized" ]

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -80,9 +80,12 @@ module HathiTrust
     Sequel.connect(Services[:db_connection_string], login_timeout: 2, pool_timeout: 100, max_connections: 6)
   end
 
+  # From the Sequel Docs (https://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html):
+  # Note that when using a JDBC adapter, the best way to use Sequel is via Sequel.connect
+  # using a connection string, NOT Sequel.jdbc
   Services.register(:db_connection_string) do
-    "jdbc:mysql://#{ENV["MYSQL_HOST"]}/#{ENV["MYSQL_DATABASE"]}? \
-    user=#{ENV["MYSQL_USER"]}&password=#{ENV["MYSQL_PASSWORD"]}& \
+    "jdbc:mysql://#{ENV["MARIADB_HT_RO_HOST"]}/#{ENV["MARIADB_HT_RO_DATABASE"]}? \
+    user=#{ENV["MARIADB_HT_RO_USERNAME"]}&password=#{ENV["MARIADB_HT_RO_PASSWORD"]}& \
     useTimezone=true&serverTimezone=UTC"
   end
 


### PR DESCRIPTION
- Change connection string to use new ENV names
  - Add note about connection string being the anointed method for JDBC connections in Sequel (alas)
- Remove `NO_DB` env in docker compose so we exercise the DB connection a bit in our tests