### PR TITLE
Dev 1516 rename oclc concordance fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     naconormalizer (1.0.1-java)
     net-http (0.6.0)
       uri
-    nokogiri (1.18.1-java)
+    nokogiri (1.18.3-java)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.6.0)

--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ and `config/env`. The defaults in the repository suffice for testing under Docke
   * `JOURNAL_DIRECTORY` location of journal files (see Date-Independent Indexing above) defaulting
     to `journal/` inside the repo directory.
   * `LOG_DIR` where to store logs, defaults to `logs/` inside the repo directory.
-  * `MYSQL_HOST`, `MYSQL_DATABASE`, `MYSQL_USER`, `MYSQL_PASSWORD` *required* unless run with `NO_DB`.
+  * `MARIADB_HT_RO_USERNAME`, `MARIADB_HT_RO_PASSWORD`, `MARIADB_HT_RO_HOST`, `MARIADB_HT_RO_DATABASE`
+    *required* unless run with `NO_DB`.
   * `NO_DB` if you want to skip all the database stuff. Useful for testing. Implied by `NO_EXTERNAL_DATA`.
   * `NO_EXTERNAL_DATA` combines `NO_DB`, `NO_REDIRECTS`
   * `NO_REDIRECTS` do not read catalog redirects file. Implied by `NO_EXTERNAL_DATA`.

--- a/lib/ht_traject/oclc_resolution.rb
+++ b/lib/ht_traject/oclc_resolution.rb
@@ -4,8 +4,8 @@ module HathiTrust
   class OCLCResolution
     def self.query
       return @query if @query
-      sql_expr = "select SQL_NO_CACHE o2.oclc, o2.canonical from oclc_concordance o1, oclc_concordance o2
-                  where o2.canonical = o1.canonical and (o1.oclc = ? OR o1.canonical = ?)"
+      sql_expr = "select SQL_NO_CACHE o2.variant, o2.canonical from oclc_concordance o1, oclc_concordance o2
+                  where o2.canonical = o1.canonical and (o1.variant = ? OR o1.canonical = ?)"
 
 
       raw_query = Services[:db][sql_expr, :$oclc, :$oclc]
@@ -15,7 +15,7 @@ module HathiTrust
     def self.all_resolved_oclcs(oclcs)
       oclcs = Array(oclcs).compact
       return [] if oclcs.empty?
-      resolved = oclcs.flat_map{|o| self.query.call(oclc: o)}.flat_map{|x| [x[:oclc], x[:canonical]]}
+      resolved = oclcs.flat_map{|o| self.query.call(oclc: o)}.flat_map{|x| [x[:variant], x[:canonical]]}
       resolved.concat(oclcs).flatten.map(&:to_s).uniq
      end
 

--- a/spec/ht_traject/oclc_resolution_spec.rb
+++ b/spec/ht_traject/oclc_resolution_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe HathiTrust::OCLCResolution do
+  # A sample of data from the current table
+  let(:oclc_sample_data) {
+    [
+      # variant, canonical
+      [1429614234, 1431896995],
+      [1266390115, 1431896866],
+      [1424497674, 1431202652],
+      [1430755151, 1431202613],
+      [1430658683, 1431202613],
+      [1430755662, 1431202593],
+      [1430661200, 1431202593],
+      [1431033788, 1431202557],
+      [1430755166, 1431202510],
+      [1430755684, 1431202283]
+    ]
+  }
+
+  around(:each) do |example|
+    HathiTrust::Services[:db][:oclc_concordance].truncate
+    HathiTrust::Services[:db][:oclc_concordance].import([:variant, :canonical], oclc_sample_data)
+    example.run
+  end
+
+  describe ".query" do
+    it "returns a query" do
+      expect(described_class.query).not_to be_nil
+    end
+  end
+  
+  describe ".all_resolved_oclcs" do
+    it "returns empty Array for empty OCLC list" do
+      expect(described_class.all_resolved_oclcs([])).to eq([])
+    end
+
+    it "returns all OCLCs for noncanonical OCLCs" do
+      expect(described_class.all_resolved_oclcs([1429614234]).sort).to eq(["1429614234", "1431896995"].sort)
+    end
+
+    it "returns all OCLCs for canonical OCLCs" do
+      expect(described_class.all_resolved_oclcs([1431896995]).sort).to eq(["1429614234", "1431896995"].sort)
+    end
+    
+    it "preserves OCLCs not found in table" do
+      expect(described_class.all_resolved_oclcs([1])).to eq(["1"])
+    end
+  end
+end

--- a/spec/ht_traject/oclc_resolution_spec.rb
+++ b/spec/ht_traject/oclc_resolution_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe HathiTrust::OCLCResolution do
       expect(described_class.query).not_to be_nil
     end
   end
-  
+
   describe ".all_resolved_oclcs" do
     it "returns empty Array for empty OCLC list" do
       expect(described_class.all_resolved_oclcs([])).to eq([])
@@ -44,7 +44,7 @@ RSpec.describe HathiTrust::OCLCResolution do
     it "returns all OCLCs for canonical OCLCs" do
       expect(described_class.all_resolved_oclcs([1431896995]).sort).to eq(["1429614234", "1431896995"].sort)
     end
-    
+
     it "preserves OCLCs not found in table" do
       expect(described_class.all_resolved_oclcs([1])).to eq(["1"])
     end


### PR DESCRIPTION
DEV-1516 rename oclc concordance fields
  - Rename fields in `lib/ht_traject/oclc_resolution.rb` Sequel query
  - Add very basic `OCLCResolution` spec.