### PR TITLE
DEV-1578 Only release catalog if indexing succeeds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.2)
+    uri (1.0.3)
     yell (2.2.2)
     zinzout (0.1.1)
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ and `config/env`. The defaults in the repository suffice for testing under Docke
 ## Environment variables
 
   * `DDIR` data directory, defaults to `/htsolr/catalog/prep`
+  * `FLAGS_DIRECTORY` location for temporary `STOPCATALOGRELEASE` file, defaults to `DDIR/flags`
   * `JOURNAL_DIRECTORY` location of journal files (see Date-Independent Indexing above) defaulting
     to `journal/` inside the repo directory.
   * `LOG_DIR` where to store logs, defaults to `logs/` inside the repo directory.

--- a/lib/cictl/stop_release.rb
+++ b/lib/cictl/stop_release.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CICTL
+  # A class that controls the STOPCATALOGRELEASE file
+  # which is written at the beginning of `cictl index` commands
+  # and removed if all goes well.
+
+  # File location is controlled by the FLAGS_DIRECTORY environment variable
+  # and defaults to DDIR + "flags", mainly for running under Docker.
+  # This class will create FLAGS_DIRECTORY if necessary but it is recommended
+  # that the directory be created beforehand with the desired permissions.
+  # This feature is more about ease of testing than anything else.
+  class StopRelease
+    FILE_NAME = "STOPCATALOGRELEASE"
+
+    def path
+      @path ||= File.join(flags_directory, FILE_NAME)
+    end
+
+    def write
+      if !File.directory?(flags_directory)
+        FileUtils.mkdir_p flags_directory
+      end
+      FileUtils.touch path
+    end
+
+    def remove
+      FileUtils.rm path, force: true
+    end
+
+    private
+
+    def flags_directory
+      ENV["FLAGS_DIRECTORY"] || File.join(HathiTrust::Services[:data_directory], "flags")
+    end
+  end
+end

--- a/lib/cictl/stop_release.rb
+++ b/lib/cictl/stop_release.rb
@@ -7,9 +7,8 @@ module CICTL
 
   # File location is controlled by the FLAGS_DIRECTORY environment variable
   # and defaults to DDIR + "flags", mainly for running under Docker.
-  # This class will create FLAGS_DIRECTORY if necessary but it is recommended
-  # that the directory be created beforehand with the desired permissions.
-  # This feature is more about ease of testing than anything else.
+  # For ease of testing this class will create FLAGS_DIRECTORY if necessary; however,
+  # it is recommended that the directory be created beforehand with the desired permissions.
   class StopRelease
     FILE_NAME = "STOPCATALOGRELEASE"
 

--- a/spec/cictl/stop_release_spec.rb
+++ b/spec/cictl/stop_release_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CICTL::StopRelease do
+  around(:each) do |example|
+    with_test_environment do |tmpdir|
+      @tmpdir = tmpdir
+      example.run
+    end
+  end
+
+  let(:stop_release) { described_class.new }
+
+  describe ".new" do
+    it "creates a CICTL::StopRelease object" do
+      expect(stop_release).to be_kind_of(CICTL::StopRelease)
+    end
+  end
+
+  describe "#path" do
+    it "returns a path to the STOPCATALOGRELEASE file" do
+      expect(stop_release.path).to include(CICTL::StopRelease::FILE_NAME)
+    end
+
+    it "returns default if FLAGS_DIRECTORY is not set" do
+      ClimateControl.modify(FLAGS_DIRECTORY: nil) do
+        expect(stop_release.path).to include(HathiTrust::Services[:data_directory])
+      end
+    end
+  end
+
+  describe "#write" do
+    it "writes a file at `path`" do
+      stop_release.write
+      expect(File.exist?(stop_release.path)).to eq(true)
+    end
+
+    it "creates FLAGS_DIRECTORY if necessary" do
+      new_flags_directory = File.join(@tmpdir, "a_strange_place_to_put_flags")
+      ClimateControl.modify(FLAGS_DIRECTORY: new_flags_directory) do
+        stop_release.write
+        expect(stop_release.path).to include(new_flags_directory)
+        expect(File.directory?(new_flags_directory)).to eq(true)
+      end
+    end
+  end
+
+  describe "#remove" do
+    it "removes existing file at `path`" do
+      stop_release.write
+      stop_release.remove
+      expect(File.exist?(stop_release.path)).to eq(false)
+    end
+
+    it "does nothing if there is no stop release file at `path`" do
+      stop_release.remove
+      expect(File.exist?(stop_release.path)).to eq(false)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,8 @@ require_relative "examples"
 def with_test_environment
   CICTL::SolrClient.new.empty!.commit!
   Dir.mktmpdir do |tmpdir|
-    ClimateControl.modify(CICTL_ZEPHIR_FILE_TEMPLATE_PREFIX: "sample") do
+    flags_directory = File.join(tmpdir, "flags")
+    ClimateControl.modify(CICTL_ZEPHIR_FILE_TEMPLATE_PREFIX: "sample", FLAGS_DIRECTORY: flags_directory) do
       old_logfile_directory = HathiTrust::Services[:logfile_directory]
       old_journal_directory = HathiTrust::Services[:journal_directory]
       new_logfile_directory = File.join(tmpdir, "logs")


### PR DESCRIPTION
- Add `StopRelease` class that handles writing and removing `STOPCATALOGRELEASE` file in `FLAGS_DIRECTORY`
- `cictl index` commands use `preflight` and `postflight` to read and remove these, respectively
- Changes to README and test helper to reflect addition of `FLAGS_DIRECTORY`

Note: `ht_tanka` changes made in parallel, q.v.

Further note: addressing CVE-2025-27221 here because Dependabot may have issues proposing fixes for JRuby. This is a minimalist `bundle update --conservative uri` version bump.