### PR TITLE
Up SolrClient default timeout from 15 to 120 seconds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     naconormalizer (1.0.1-java)
     net-http (0.6.0)
       uri
-    nokogiri (1.18.3-java)
+    nokogiri (1.18.7-java)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.6.0)

--- a/lib/cictl/solr_client.rb
+++ b/lib/cictl/solr_client.rb
@@ -10,7 +10,7 @@ module CICTL
   class SolrClient < SimpleDelegator
     # @param [RSolr] rsolr An existing rsolr instance
     # @param [Fixnum] timeout Timeout, in seconds
-    def initialize(rsolr = nil, timeout: 15)
+    def initialize(rsolr = nil, timeout: 120)
       rsolr ||= RSolr.connect url: solr_url, timeout: timeout, open_timeout: 2
       super(rsolr)
     end


### PR DESCRIPTION
To address `RSolr::Error::Timeout` after commit for metadata-processong workflow