### PR TITLE
Upgrade Solr version. From Solr 8.11.2 to Solr 8.11.4

### DIFF
--- a/solr/solrcloud/Dockerfile
+++ b/solr/solrcloud/Dockerfile
@@ -1,3 +1,3 @@
-FROM solr:8.11
+FROM solr:8.11.4
 
 COPY --chown=solr:solr lib /var/solr/lib


### PR DESCRIPTION
This PR (pull request) changes the Dockerfile, upgrading the Solr image from Solr 8.11.2 to Solr 8.11.4. It is related to another PR on [argocd-kubeadmin](https://github.com/hathitrust/argocd-kubeadmin) repository that updates the image used on the Solr operator. 

As part of this update, the process to create a Solr backup has been tested. The `solr/solrcloud/README.md` file has been updated with the command used to create backups of solr collections.