### PR TITLE
Update dependencies; update to jruby 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:9.4-jdk17 AS base
+FROM jruby:10.0-jdk21 AS base
 ARG UNAME=app
 ARG UID=1000
 ARG GID=1000
@@ -12,7 +12,7 @@ WORKDIR /app
 
 # USER $UNAME
 ENV BUNDLE_PATH /gems
-RUN gem install bundler --version "~> 2.5.23"
+RUN gem install bundler
 
 FROM base AS development
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 group :development, :test do
-  gem "bundler", "~>2.0"
+  gem "bundler"
   gem "climate_control"
   gem "rake"
   gem "pry"
@@ -21,7 +21,7 @@ gem "http", "~>5.0"
 gem "httpclient"
 gem "httpx"
 gem "library_stdnums"
-gem "marc-fastxmlwriter", "~> 1.1"
+gem "marc"
 gem "match_map"
 gem "push_metrics", git: "https://github.com/hathitrust/push_metrics"
 gem "rsolr"
@@ -29,9 +29,7 @@ gem "semantic_logger"
 gem "sequel"
 gem "thor"
 gem "traject", "~>3.0"
-gem "traject_alephsequential_reader"
 gem "traject_umich_format"
-gem "yell"
 gem "zinzout"
 
 if defined? JRUBY_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,17 +9,17 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (3.2.3-java)
+    bigdecimal (4.0.1-java)
     builder (3.3.0)
     canister (0.9.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.5)
-    crack (1.0.0)
+    concurrent-ruby (1.3.6)
+    crack (1.0.1)
       bigdecimal
       rexml
     csv (3.3.5)
@@ -29,19 +29,20 @@ GEM
     domain_name (0.6.20240107)
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
-    dotenv (3.1.8)
+    dotenv (3.2.0)
     faraday (2.14.0)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
-    ffi (1.17.2-java)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    ffi (1.17.3-java)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
     hashdiff (1.2.1)
-    hashie (5.0.0)
+    hashie (5.1.0)
+      logger
     http-2 (1.1.1)
     http (5.3.1)
       addressable (~> 2.8)
@@ -53,10 +54,11 @@ GEM
     http-form_data (2.3.0)
     httpclient (2.9.0)
       mutex_m
-    httpx (1.6.2)
+    httpx (1.7.2)
       http-2 (>= 1.0.0)
+    io-console (0.8.2-java)
     jdbc-mysql (9.1.0.1)
-    json (2.15.1-java)
+    json (2.18.0-java)
     language_server-protocol (3.17.0.5)
     library_stdnums (1.6.0)
     lint_roller (1.1.0)
@@ -64,59 +66,60 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
-    marc (1.3.0)
+    marc (1.4.0)
       nokogiri (~> 1.0)
       rexml
     marc-fastxmlwriter (1.1.0)
       marc (~> 1.0)
     marc-marc4j (1.0.0-java)
       marc (~> 1)
-    marc_alephsequential (2.0.0)
-      marc (~> 1)
-      yell (~> 2)
     match_map (3.0.0)
     method_source (1.1.0)
-    milemarker (1.0.1)
+    milemarker (1.0.2)
+      logger
     mutex_m (0.3.0)
     naconormalizer (1.0.1-java)
-    net-http (0.6.0)
-      uri
-    nokogiri (1.18.10-java)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    nokogiri (1.19.0-java)
       racc (~> 1.4)
     parallel (1.27.0)
-    parser (3.3.9.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
-    prism (1.5.1)
+    prism (1.9.0)
     prometheus-client (4.2.5)
       base64
-    pry (0.15.2-java)
+    pry (0.16.0-java)
       coderay (~> 1.1)
       method_source (~> 1.0)
+      reline (>= 0.6.0)
       spoon (~> 0.0)
-    public_suffix (6.0.2)
+    public_suffix (7.0.2)
     racc (1.8.1-java)
     rainbow (3.1.1)
-    rake (13.3.0)
+    rake (13.3.1)
     regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
     rexml (3.4.4)
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
-    rspec (3.13.1)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.5)
+    rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.5)
+    rspec-mocks (3.13.7)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.6)
-    rubocop (1.80.2)
+    rubocop (1.82.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -124,20 +127,20 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.46.0, < 2.0)
+      rubocop-ast (>= 1.48.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.47.1)
+    rubocop-ast (1.49.0)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
-    rubocop-performance (1.25.0)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
     semantic_logger (4.17.0)
       concurrent-ruby (~> 1.0)
-    sequel (5.97.0)
+    sequel (5.100.0)
       bigdecimal
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -149,19 +152,19 @@ GEM
     slop (4.10.1)
     spoon (0.0.6)
       ffi
-    standard (1.51.1)
+    standard (1.53.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.80.2)
+      rubocop (~> 1.82.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
     standard-custom (1.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.50)
-    standard-performance (1.8.0)
+    standard-performance (1.9.0)
       lint_roller (~> 1.1)
-      rubocop-performance (~> 1.25.0)
-    thor (1.4.0)
+      rubocop-performance (~> 1.26.0)
+    thor (1.5.0)
     timecop (0.9.10)
     traject (3.8.3)
       concurrent-ruby (>= 0.8.0)
@@ -179,16 +182,12 @@ GEM
     traject-marc4j_reader (1.1.0-java)
       marc (~> 1.0)
       marc-marc4j (~> 1.0)
-    traject_alephsequential_reader (1.1.2)
-      marc (~> 1)
-      marc_alephsequential (~> 2)
-      yell
     traject_umich_format (0.4.4)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
-    uri (1.0.3)
-    webmock (3.25.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    webmock (3.26.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -197,9 +196,10 @@ GEM
 
 PLATFORMS
   universal-java-17
+  universal-java-21
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler
   canister
   climate_control
   date_named_file
@@ -210,7 +210,7 @@ DEPENDENCIES
   httpx
   jdbc-mysql
   library_stdnums
-  marc-fastxmlwriter (~> 1.1)
+  marc
   match_map
   naconormalizer
   pry
@@ -227,11 +227,9 @@ DEPENDENCIES
   timecop
   traject (~> 3.0)
   traject-marc4j_reader
-  traject_alephsequential_reader
   traject_umich_format
   webmock
-  yell
   zinzout
 
 BUNDLED WITH
-   2.6.9
+  4.0.3

--- a/indexers/common_ht.rb
+++ b/indexers/common_ht.rb
@@ -71,7 +71,7 @@ to_field 'ht_rightscode' do |_record, acc, context|
 end
 
 to_field 'htsource' do |_record, acc, context|
-  cc_to_of = HathiTrust::Services[:collection_map]
+  cc_to_of = HathiTrust::Services.collection_map
   if context.clipboard[:ht][:has_items]
     acc.concat context.clipboard[:ht][:items].collection_codes.map { |x| cc_to_of[x] }
   end

--- a/lib/cictl/solr_client.rb
+++ b/lib/cictl/solr_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rsolr"
 require "delegate"
 require "pathname"
@@ -81,7 +83,7 @@ module CICTL
     def send_jsonl(filename, batch_size: 1000)
       Zinzout.zin(filename) do |infile|
         infile.each_slice(batch_size) do |batch|
-          body = "[" << batch.join(",") << "]"
+          body = "[" + batch.join(",") + "]"
           batch_sender_client.post(update_url, body)
         end
       end

--- a/spec/cictl/index_command_spec.rb
+++ b/spec/cictl/index_command_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe CICTL::IndexCommand do
         CICTL::Examples.of_type(:full, :upd)
           .reject { |e| e[:date] == "20230103" }
           .each do |ex|
-          CICTL::Examples.journal_for(example: ex).write!
+            CICTL::Examples.journal_for(example: ex).write!
         end
 
         CICTL::Commands.start(["index", "continue", "--quiet"])

--- a/spec/indexers/ht_spec.rb
+++ b/spec/indexers/ht_spec.rb
@@ -11,8 +11,12 @@ RSpec.describe "indexers/ht" do
     end
   end
 
+  let(:traject_logger) do
+    CICTL::LoggerFactory.new(quiet: true).logger(owner: "rspec")
+  end
+
   let(:indexer) do
-    Traject::Indexer::MarcIndexer.new do
+    Traject::Indexer::MarcIndexer.new(logger: traject_logger) do
       [
         "./writers/null.rb",
         "./indexers/common.rb",


### PR DESCRIPTION
Most of the work for jruby 10 was addressing the warnings about frozen strings.

We should wait to merge this until marc-fastxmlwriter is updated with https://github.com/billdueber/marc-fastxmlwriter/pull/3 is merged.