### PR TITLE
ETT-1466 Figure out issue with catalog indexing update.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     http-form_data (2.3.0)
     httpclient (2.9.0)
       mutex_m
-    httpx (1.7.5)
+    httpx (1.7.6)
       http-2 (>= 1.1.3)
     io-console (0.8.2-java)
     jdbc-mysql (9.1.0.1)


### PR DESCRIPTION
 - We have good evidence that httpx 1.7.5 caused indexing to hang and that 1.7.6 fixes the issues.
 - This this is currently in metadata-workflow-testing and has been checked against `zephir_upd_20260409.json.gz`, exiting normally.