### PR TITLE
Bumping Lucene version to use the last one and also the compatible on…

### DIFF
--- a/solr/solrcloud/conf/solrconfig.xml
+++ b/solr/solrcloud/conf/solrconfig.xml
@@ -34,8 +34,13 @@
        get all bug fixes and improvements. It is highly recommended
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
+
+       To know the compatible Solr and lucene version you must check
+       http://localhost:8983/solr/admin/info/system on the image you used
+       For example, for the image solr:9.10.1, solr --> "solr-spec-version":"9.10.1" and
+       lucene --> "lucene-spec-version":"9.12.3"
   -->
-  <luceneMatchVersion>9.10.0</luceneMatchVersion>
+  <luceneMatchVersion>9.12.3</luceneMatchVersion>
 
   <!-- Data Directory
 

--- a/solr/solrcloud/docker-compose.yml
+++ b/solr/solrcloud/docker-compose.yml
@@ -11,7 +11,9 @@ x-healthcheck-defaults: &healthcheck-defaults
 
 services:
   solr-sdr-catalog:
-    image: ghcr.io/hathitrust/catalog-solr:solrcloud-9.10.1
+    build:
+        context: ../..
+        dockerfile: solr/solrcloud/Dockerfile
     ports:
       - "9033:9033"
     command: solr-foreground -p 9033 # Explicitly ensures to start Solr on port 9033.


### PR DESCRIPTION
@eumalin, this PR is just to update the Lucene version used on the Catalog image. This change is compatible with the versions used to generate the JARs. If this change makes sense to you, you can merge it into your branch.

I've tested, and it works

To ensure this change works, we could run

```
cd solr/solrcloud
docker compose up -d
```

You should see 2000 documents in Solr http://localhost:9033/solr/#/catalog/query?q=*:*&q.op=OR&indent=true&useParams=.

When you merge this change, I can test it again. 